### PR TITLE
Implement vertical status message mode

### DIFF
--- a/control.html
+++ b/control.html
@@ -143,6 +143,51 @@
         ⚠️ 未更新の変更があります - 更新ボタンを押してください
       </div>
 
+      <!-- 🔥 新規追加: 表示モード選択 -->
+      <div class="form-group mode-selection-group">
+        <label>表示モード</label>
+        <div class="mode-selector">
+          <label class="mode-option">
+            <input type="radio" name="displayMode" value="rooms" checked>
+            <span>診察順表示</span>
+          </label>
+          <label class="mode-option">
+            <input type="radio" name="displayMode" value="message">
+            <span>ステータスメッセージ</span>
+          </label>
+          <label class="mode-option">
+            <input type="radio" name="displayMode" value="hidden">
+            <span>非表示</span>
+          </label>
+        </div>
+      </div>
+
+      <!-- 🔥 新規追加: ステータスメッセージ設定エリア -->
+      <div id="statusMessageArea" class="status-message-area" style="display: none;">
+        <div class="form-group">
+          <label>ステータスメッセージ <span class="text-limit">(30文字以内)</span></label>
+          <textarea id="statusMessageText" rows="2" maxlength="30" 
+                    placeholder="ステータスメッセージを入力してください&#10;改行も可能です"></textarea>
+          <div class="text-counter">
+            <span id="statusMessageCounter">0/30文字</span>
+          </div>
+        </div>
+
+        <!-- 定型文ボタン -->
+        <div class="preset-buttons">
+          <label>定型文:</label>
+          <button type="button" class="btn btn-sm preset-btn" data-preset="part1_wait">第１部開始まで</button>
+          <button type="button" class="btn btn-sm preset-btn" data-preset="part2_wait">第２部開始まで</button>
+          <button type="button" class="btn btn-sm preset-btn" data-preset="part3_wait">第３部開始まで</button>
+          <button type="button" class="btn btn-sm preset-btn" data-preset="closed">受付終了</button>
+          <button type="button" class="btn btn-sm preset-btn" data-preset="holiday">本日休診</button>
+          <button type="button" class="btn btn-sm preset-btn" data-preset="preparation">診療準備中</button>
+        </div>
+      </div>
+
+      <!-- 既存の診察順設定エリア -->
+      <div id="roomSettingsArea">
+
       <!-- 🔥 改良: 編集エリア -->
       <div class="room-edit-wrapper">
         <!-- 第1診察室 -->
@@ -206,6 +251,7 @@
 
       <button class="btn btn-success" id="saveButton" onclick="saveStatus()">💾 診察順表示を更新</button>
       <button class="btn btn-danger" onclick="resetStatus()">🔄 リセット</button>
+      </div>
     </div>
   </details>
 

--- a/css/style.css
+++ b/css/style.css
@@ -1023,3 +1023,268 @@ details.card .card-content {
     border: 2px solid #000;
   }
 }
+
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   🔥 ステータスメッセージ機能 専用CSS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+
+/* 表示モード選択 */
+.mode-selection-group {
+  background: #e3f2fd;
+  padding: 15px;
+  border-radius: 8px;
+  margin-bottom: 20px;
+  border: 2px solid #2196f3;
+}
+
+.mode-selector {
+  display: flex;
+  gap: 15px;
+  margin: 10px 0;
+  flex-wrap: wrap;
+}
+
+.mode-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  padding: 10px 15px;
+  border: 2px solid #e9ecef;
+  border-radius: 8px;
+  background: white;
+  transition: all 0.3s ease;
+  font-weight: 500;
+  min-width: 120px;
+  justify-content: center;
+}
+
+.mode-option:hover {
+  background: #f8f9fa;
+  border-color: #667eea;
+}
+
+.mode-option input[type="radio"] {
+  width: auto;
+  margin: 0;
+}
+
+.mode-option input:checked + span {
+  font-weight: bold;
+  color: #667eea;
+}
+
+.mode-option:has(input:checked) {
+  background: #667eea;
+  border-color: #667eea;
+  color: white;
+}
+
+.mode-option:has(input:checked) span {
+  color: white;
+}
+
+/* ステータスメッセージエリア */
+.status-message-area {
+  background: #fff8e1;
+  padding: 20px;
+  border-radius: 10px;
+  margin: 15px 0;
+  border: 2px solid #ff9800;
+  animation: slideIn 0.3s ease;
+}
+
+@keyframes slideIn {
+  from { opacity: 0; transform: translateY(-10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.status-message-area .form-group label {
+  font-weight: bold;
+  color: #e65100;
+}
+
+.text-limit {
+  font-size: 0.8rem;
+  color: #ff5722;
+  font-weight: normal;
+}
+
+.status-message-area textarea {
+  font-size: 1.1rem;
+  line-height: 1.4;
+  resize: vertical;
+  min-height: 60px;
+}
+
+.text-counter {
+  text-align: right;
+  font-size: 0.85rem;
+  color: #666;
+  margin-top: 5px;
+  font-weight: 500;
+}
+
+.text-counter.warning {
+  color: #ff5722;
+  font-weight: bold;
+}
+
+/* 定型文ボタン */
+.preset-buttons {
+  margin-top: 15px;
+  padding-top: 15px;
+  border-top: 1px solid #ffcc02;
+}
+
+.preset-buttons label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 600;
+  color: #e65100;
+}
+
+.preset-btn {
+  margin: 3px;
+  padding: 6px 12px;
+  background: #ff9800;
+  color: white;
+  font-size: 0.85rem;
+  border: none;
+  border-radius: 15px;
+  transition: all 0.2s ease;
+  font-weight: 500;
+}
+
+.preset-btn:hover {
+  background: #f57c00;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.preset-btn:active {
+  transform: translateY(0);
+}
+
+/* プレビューエリアの拡張 */
+.preview-status-message {
+  background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+  color: white;
+  padding: 20px;
+  border-radius: 10px;
+  text-align: center;
+  min-height: 200px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+}
+
+.preview-message-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: stretch;
+  gap: 30px;
+  height: 100%;
+}
+
+.preview-message-line {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  font-weight: bold;
+  color: white;
+  text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
+  flex: 1;
+}
+
+.preview-message-single {
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  font-weight: bold;
+  color: white;
+  text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   🔥 表示画面用 ステータスメッセージ CSS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+
+/* ステータスメッセージモード専用スタイル */
+.status-card.message-mode {
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 30px 20px;
+  min-height: 400px;
+}
+
+.vertical-message-container {
+  display: flex;
+  flex-direction: row; /* 縦書きでは行が水平方向 */
+  justify-content: center;
+  align-items: stretch;
+  gap: clamp(20px, 5vw, 60px);
+  width: 100%;
+  height: 100%;
+}
+
+.vertical-message-line {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  font-weight: bold;
+  color: #2c3e50;
+  text-align: center;
+  flex: 1;
+  text-shadow: 1px 1px 2px rgba(0,0,0,0.1);
+}
+
+/* 1行表示用（特大） */
+.vertical-message-single {
+  width: 100%;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  font-weight: bold;
+  color: #2c3e50;
+  text-shadow: 2px 2px 4px rgba(0,0,0,0.2);
+}
+
+/* レスポンシブ対応 */
+@media (max-height: 600px) {
+  .status-card.message-mode {
+    padding: 20px 15px;
+    min-height: 300px;
+  }
+
+  .vertical-message-container {
+    gap: 15px;
+  }
+}
+
+@media (max-width: 500px) {
+  .status-card.message-mode {
+    padding: 15px 10px;
+  }
+
+  .vertical-message-container {
+    gap: 10px;
+  }
+}

--- a/data/status.json
+++ b/data/status.json
@@ -1,17 +1,23 @@
 {
-    "room1": {
-        "label": "第1診察室　小石",
-        "number": 0,
-        "visible": true
-    },
-    "room2": {
-        "label": "第2診察室   高松",
-        "number": 0,
-        "visible": true
-    },
-    "lastUpdated": "2025-06-30 17:16:19",
-    "updatedBy": {
-        "ip": "118.6.2.215",
-        "userAgent": "Mozilla\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/137.0.0.0 Safari\/537.36"
-    }
+  "mode": "rooms",
+  "statusMessage": {
+    "text": "",
+    "visible": false,
+    "preset": null
+  },
+  "room1": {
+    "label": "第1診察室　小石",
+    "number": 0,
+    "visible": true
+  },
+  "room2": {
+    "label": "第2診察室   高松",
+    "number": 0,
+    "visible": true
+  },
+  "lastUpdated": "2025-06-30 17:16:19",
+  "updatedBy": {
+    "ip": "118.6.2.215",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36"
+  }
 }


### PR DESCRIPTION
## Summary
- support three display modes including new vertical status message
- extend status.json data structure
- update PHP save logic to validate new fields
- add mode selector and status message editor in control panel
- implement status message preview and rendering
- style updates for vertical message display

## Testing
- `npm test` *(fails: Could not read package.json)*
- `php -l php/save_status.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686398b88e7083279efba89b6a0ffc25