### PR TITLE
Adjust layout for long playlist titles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -157,6 +157,13 @@ html, body {
   transition: var(--transition-smooth);
 }
 
+.main-content.wide-card {
+  max-width: clamp(1100px, 72vw, 1500px);
+  width: 100%;
+  align-items: stretch;
+  justify-self: center;
+}
+
 .main-content.show {
   opacity: 1;
   transform: translateY(0);
@@ -175,6 +182,23 @@ html, body {
   white-space: pre-wrap;         /* 改行文字を有効化 */
   word-break: break-word;        /* 長い単語を適切に改行 */
   overflow-wrap: break-word;     /* 単語の途中でも改行可能 */
+}
+
+.main-content h2.long-title,
+.main-content h2.xlong-title {
+  line-height: 1.2;
+  margin-bottom: 32px;
+}
+
+.main-content h2.long-title {
+  font-size: clamp(3.4rem, 4.6vw, 4rem);
+}
+
+.main-content h2.xlong-title {
+  font-size: clamp(3rem, 4.2vw, 3.6rem);
+  line-height: 1.15;
+  margin-bottom: 26px;
+  letter-spacing: -0.01em;
 }
 
 .main-content p {
@@ -725,11 +749,24 @@ details.card .card-content {
 @media (max-width: 1200px) {
   .display-container {
     grid-template-columns: 1fr 400px;
-    grid-template-areas: 
+    grid-template-areas:
       "category status"
       "content status"
       "content status"
       "message status";
+  }
+
+  .main-content.wide-card {
+    max-width: clamp(820px, 88vw, 1100px);
+  }
+
+  .main-content h2.long-title {
+    font-size: clamp(3rem, 4.8vw, 3.6rem);
+  }
+
+  .main-content h2.xlong-title {
+    font-size: clamp(2.8rem, 4.4vw, 3.2rem);
+    margin-bottom: 24px;
   }
 }
 
@@ -748,6 +785,23 @@ details.card .card-content {
     --title-size: calc(4.5rem * 0.6);
     --content-size: calc(2.8rem * 0.6);
     --status-number: calc(11.0rem * 0.6);
+  }
+
+  .main-content.wide-card {
+    max-width: 100%;
+    align-items: center;
+    justify-self: stretch;
+  }
+
+  .main-content h2.long-title {
+    font-size: clamp(2.6rem, 6vw, 3.2rem);
+    margin-bottom: 24px;
+  }
+
+  .main-content h2.xlong-title {
+    font-size: clamp(2.4rem, 5.5vw, 2.9rem);
+    line-height: 1.12;
+    margin-bottom: 20px;
   }
 }
 

--- a/js/display.js
+++ b/js/display.js
@@ -421,14 +421,29 @@ initializeBackgroundVideo() {
     setTimeout(() => {
       // コンテンツ更新
       this.mainContent.innerHTML = '';
-      
+      this.mainContent.classList.remove('wide-card');
+
       const titleElement = document.createElement('h2');
       const textElement = document.createElement('p');
-      
+
+      const itemIcon = item.icon || '💡';
+      const itemTitle = item.title || '';
+      const titleText = `${itemIcon} ${itemTitle}`;
+
+      // タイトルの長さを計測し、クラスを調整
+      const titleLength = Array.from(titleText).length;
+      if (titleLength > 28) {
+        titleElement.classList.add('long-title', 'xlong-title');
+        this.mainContent.classList.add('wide-card');
+      } else if (titleLength > 22) {
+        titleElement.classList.add('long-title');
+        this.mainContent.classList.add('wide-card');
+      }
+
       // タイトルとテキストを設定
-      TextUtils.setElementText(titleElement, `${item.icon || '💡'} ${item.title}`, true);
+      TextUtils.setElementText(titleElement, titleText, true);
       TextUtils.setElementText(textElement, item.text, true);
-      
+
       this.mainContent.appendChild(titleElement);
       this.mainContent.appendChild(textElement);
       


### PR DESCRIPTION
## Summary
- measure playlist item titles and toggle long/xlong title and wide-card classes during display rotation
- expand the display card styling for long titles, including responsive typography and width adjustments down to 800px

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce47bccf408327af95dca871329ba7