### PR TITLE
Add manual skip controls and playlist timer cleanup

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -215,6 +215,31 @@ html, body {
   overflow-wrap: break-word;     /* 単語の途中でも改行可能 */
 }
 
+.tip-title-button,
+.tip-body-button {
+  cursor: pointer;
+  outline: none;
+  transition: var(--transition-fast);
+}
+
+.tip-title-button:hover,
+.tip-title-button:focus-visible,
+.tip-body-button:hover,
+.tip-body-button:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 6px;
+}
+
+.tip-title-button:hover,
+.tip-title-button:focus-visible {
+  text-shadow: 3px 3px 8px rgba(0, 0, 0, 0.6);
+}
+
+.tip-body-button:hover,
+.tip-body-button:focus-visible {
+  text-shadow: 2px 2px 6px rgba(0, 0, 0, 0.5);
+}
+
 /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    メッセージエリア（改行対応）
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */


### PR DESCRIPTION
## Summary
- add a shared playback timer cleanup helper so manual and automatic transitions reset correctly
- implement skip-to-item and skip-to-file controls on displayed tips with accessible activation
- style the hidden tip controls with hover/focus affordances to hint at their interactivity

## Testing
- Manual UI verification via `php -S 0.0.0.0:8000`

------
https://chatgpt.com/codex/tasks/task_e_68d788b57fbc8327bafbbee656bfce7f