### PR TITLE
Prevent room labels from wrapping doctor names

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -318,6 +318,18 @@ html, body {
   margin-bottom: 10px;
   font-weight: bold;
   color: #495057;
+  white-space: nowrap;
+  letter-spacing: 0.03em;
+}
+
+.status-card .room-label.room-label-tight {
+  font-size: calc(var(--status-label) * 0.92);
+  letter-spacing: -0.01em;
+}
+
+.status-card .room-label.room-label-compact {
+  font-size: calc(var(--status-label) * 0.86);
+  letter-spacing: -0.02em;
 }
 
 .status-card .room-number {

--- a/js/display.js
+++ b/js/display.js
@@ -822,6 +822,9 @@ initializeBackgroundVideo() {
     const r1 = this.status.room1 || {};
     const r2 = this.status.room2 || {};
 
+    const room1Class = this.getRoomLabelClass(r1.label || '第1診察室');
+    const room2Class = this.getRoomLabelClass(r2.label || '第2診察室');
+
     const hasVisibleRoom = (r1.visible && r1.number > 0) || (r2.visible && r2.number > 0);
 
     if (!hasVisibleRoom) {
@@ -830,21 +833,36 @@ initializeBackgroundVideo() {
     }
 
     this.statusCard.style.display = 'block';
-    this.statusCard.innerHTML = `
-      <h4>🩺 診察順のご案内</h4>
-      ${r1.visible && r1.number > 0 ? `
-        <div class="room-info">
-          <div class="room-label">${r1.label || '第1診察室'}</div>
+      this.statusCard.innerHTML = `
+        <h4>🩺 診察順のご案内</h4>
+        ${r1.visible && r1.number > 0 ? `
+          <div class="room-info">
+          <div class="room-label ${room1Class}">${r1.label || '第1診察室'}</div>
           <div class="room-number">${r1.number}</div>
-        </div>
-      ` : ''}
-      ${r2.visible && r2.number > 0 ? `
-        <div class="room-info">
-          <div class="room-label">${r2.label || '第2診察室'}</div>
+          </div>
+        ` : ''}
+        ${r2.visible && r2.number > 0 ? `
+          <div class="room-info">
+          <div class="room-label ${room2Class}">${r2.label || '第2診察室'}</div>
           <div class="room-number">${r2.number}</div>
-        </div>
-      ` : ''}
-    `;
+          </div>
+        ` : ''}
+      `;
+  }
+
+  getRoomLabelClass(label) {
+    const normalized = (label || '').replace(/\s+/g, '');
+    const length = Array.from(normalized).length;
+
+    if (length >= 6) {
+      return 'room-label-compact';
+    }
+
+    if (length >= 3) {
+      return 'room-label-tight';
+    }
+
+    return '';
   }
 
   /**


### PR DESCRIPTION
## Summary
- keep room labels on a single line and tighten spacing to avoid unintended line breaks
- size room labels dynamically so 3文字以上の医師名でも表示が折り返さないように調整

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cd4b06fb083278bb97b7e467a0ceb)